### PR TITLE
fix: support base_url for embeddings

### DIFF
--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,18 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
     """Input type to send when embedding queries (e.g. 'search_query'
     for Cohere, 'RETRIEVAL_QUERY' for Vertex AI). When set,
     ``embed_query`` passes this as ``input_type``."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_base_url_alias(cls, values: Any) -> Any:
+        """Support base_url as an alias for api_base."""
+        if (
+            isinstance(values, dict)
+            and "base_url" in values
+            and "api_base" not in values
+        ):
+            return {**values, "api_base": values["base_url"]}
+        return values
 
     def _get_litellm_params(
         self, *, input_type: Optional[str] = None

--- a/tests/unit_tests/test_embeddings.py
+++ b/tests/unit_tests/test_embeddings.py
@@ -48,6 +48,31 @@ class TestLiteLLMEmbeddingsParams:
         assert params["dimensions"] == 256
         assert params["timeout"] == 30.0
 
+    def test_base_url_alias_sets_api_base(self):
+        """Test that base_url is normalized to api_base."""
+        embeddings = LiteLLMEmbeddings(
+            model="openai/text-embedding-3-small",
+            api_key="fake-key",
+            base_url="https://proxy.example/v1",
+        )
+
+        params = embeddings._get_litellm_params()
+        assert embeddings.api_base == "https://proxy.example/v1"
+        assert params["api_base"] == "https://proxy.example/v1"
+
+    def test_api_base_takes_precedence_over_base_url(self):
+        """Test that explicit api_base takes precedence over base_url."""
+        embeddings = LiteLLMEmbeddings(
+            model="openai/text-embedding-3-small",
+            api_key="fake-key",
+            api_base="https://api-base.example/v1",
+            base_url="https://base-url.example/v1",
+        )
+
+        params = embeddings._get_litellm_params()
+        assert embeddings.api_base == "https://api-base.example/v1"
+        assert params["api_base"] == "https://api-base.example/v1"
+
     def test_none_params_excluded(self):
         """Test that None-valued params are excluded from the litellm call."""
         embeddings = LiteLLMEmbeddings(

--- a/tests/unit_tests/test_embeddings_router.py
+++ b/tests/unit_tests/test_embeddings_router.py
@@ -29,6 +29,15 @@ class TestLiteLLMEmbeddingsRouterParams:
         embeddings = LiteLLMEmbeddingsRouter(router=router)
         assert embeddings.router is router
 
+    def test_base_url_alias_sets_api_base(self):
+        """Test that base_url is normalized on the router subclass."""
+        router = make_embedding_router()
+        embeddings = LiteLLMEmbeddingsRouter(
+            router=router,
+            base_url="https://proxy.example/v1",
+        )
+        assert embeddings.api_base == "https://proxy.example/v1"
+
     def test_router_params_exclude_none(self):
         """Test that None-valued params are excluded from router calls."""
         router = make_embedding_router()


### PR DESCRIPTION
## Summary
- Normalize `base_url` to `api_base` for `LiteLLMEmbeddings` before unknown fields are ignored.
- Keep explicit `api_base` precedence when both values are supplied.
- Add unit coverage for direct embeddings and the router subclass.

Fixes #202

## Validation
- `python -m pytest tests/unit_tests/test_embeddings.py tests/unit_tests/test_embeddings_router.py` - 31 passed
- `python -m ruff check langchain_litellm/embeddings/litellm.py tests/unit_tests/test_embeddings.py tests/unit_tests/test_embeddings_router.py`
- `python -m ruff format --check langchain_litellm/embeddings/litellm.py tests/unit_tests/test_embeddings.py tests/unit_tests/test_embeddings_router.py`
- `git diff --check`