### PR TITLE
fix: accept base_url as an alias for api_base in LiteLLMEmbeddings

### DIFF
--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+"""Added a new import """
 import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,21 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
             )
     """
 
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_base_url_alias(cls, values: Any) -> Any:
+        """Accept `base_url` as an alias for `api_base`.
+
+        Without this, `base_url` is silently dropped by Pydantic's
+        `extra="ignore"` (this class has no `validate_environment`).
+        The explicit `api_base` wins if both are supplied.
+        """
+        if isinstance(values, dict):
+            base_url = values.pop("base_url", None)
+            if base_url is not None and values.get("api_base") is None:
+                values["api_base"] = base_url
+        return values
+
     model: str = "openai/text-embedding-3-small"
     """Model name in litellm format (e.g. 'openai/text-embedding-3-small',
     'cohere/embed-english-v3.0', 'bedrock/amazon.titan-embed-text-v1')."""
@@ -65,7 +81,11 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
     """API key for the provider."""
 
     api_base: Optional[str] = None
-    """Base URL for the API endpoint."""
+    """Base URL for the API endpoint.
+
+    Also accepts ``base_url`` as an alias (normalized in a validator) for
+    consistency with the rest of the LangChain ecosystem. When both are
+    supplied, the explicit ``api_base`` wins."""
 
     api_version: Optional[str] = None
     """API version (e.g. for Azure)."""

--- a/tests/unit_tests/test_embeddings.py
+++ b/tests/unit_tests/test_embeddings.py
@@ -25,6 +25,34 @@ class TestLiteLLMEmbeddingsUnit(EmbeddingsUnitTests):
 
 
 class TestLiteLLMEmbeddingsParams:
+    def test_base_url_alias_sets_api_base(self) -> None:
+        """`base_url=` must populate `api_base` (regression for #202)."""
+        e = LiteLLMEmbeddings(
+            model="openai/text-embedding-3-small",
+            api_key="fake",
+            base_url="https://proxy.example/v1",  # type: ignore[call-arg]
+        )
+        assert e.api_base == "https://proxy.example/v1"
+
+    def test_api_base_still_supported(self) -> None:
+        """`api_base=` must keep working for existing callers (non-breaking)."""
+        e = LiteLLMEmbeddings(
+            model="openai/text-embedding-3-small",
+            api_key="fake",
+            api_base="https://legacy.example/v1",
+        )
+        assert e.api_base == "https://legacy.example/v1"
+
+    def test_api_base_takes_precedence_over_base_url(self) -> None:
+        """When both are supplied, the explicit `api_base` wins."""
+        e = LiteLLMEmbeddings(
+            model="openai/text-embedding-3-small",
+            api_key="fake",
+            api_base="https://explicit.example/v1",
+            base_url="https://alias.example/v1",  # type: ignore[call-arg]
+        )
+        assert e.api_base == "https://explicit.example/v1"
+
     def test_default_params(self):
         """Test default parameter values."""
         embeddings = LiteLLMEmbeddings(api_key="fake")

--- a/tests/unit_tests/test_embeddings_router.py
+++ b/tests/unit_tests/test_embeddings_router.py
@@ -23,6 +23,16 @@ class TestLiteLLMEmbeddingsRouterUnit(EmbeddingsUnitTests):
 
 
 class TestLiteLLMEmbeddingsRouterParams:
+    def test_router_inherits_base_url_alias(self) -> None:
+        """LiteLLMEmbeddingsRouter should inherit the alias with no extra code."""
+        router = make_embedding_router()
+        e = LiteLLMEmbeddingsRouter(
+            router=router,
+            model="text-embedding-3-small",
+            base_url="https://proxy.example/v1",  # type: ignore[call-arg]
+        )
+        assert e.api_base == "https://proxy.example/v1"
+
     def test_router_stored(self):
         """Test that the router instance is stored."""
         router = make_embedding_router()


### PR DESCRIPTION
Fixes #202. Companion to #189/#200. `LiteLLMEmbeddings` has no `validate_environment`, so this uses `model_validator(mode="before")` instead of `@pre_init`. `LiteLLMEmbeddingsRouter` subclasses `LiteLLMEmbeddings` without overriding this validator, so it inherits the alias automatically — verified with `test_router_inherits_base_url_alias`, no duplicate code needed in `litellm_router.py`.

`make format`, `make lint`, and `make test` all pass locally.