### PR TITLE
fix: support base_url as alias for api_base in ChatLiteLLM and LiteLLMEmbeddings

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -80,7 +80,7 @@ from langchain_core.utils import get_from_dict_or_env, pre_init
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
 from litellm.types.utils import Delta
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self, is_typeddict
 
 from langchain_litellm._version import __version__
@@ -409,6 +409,10 @@ def _convert_message_to_dict(message: BaseMessage) -> Dict[str, Any]:
 class ChatLiteLLM(BaseChatModel):
     """Chat model that uses the LiteLLM API."""
 
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+
     client: Any = None  #: :meta private:
     model: str = "gpt-3.5-turbo"
     model_name: Optional[str] = None
@@ -422,7 +426,7 @@ class ChatLiteLLM(BaseChatModel):
     openrouter_api_key: Optional[str] = None
     api_key: Optional[str] = None
     streaming: bool = False
-    api_base: Optional[str] = None
+    api_base: Optional[str] = Field(default=None, alias="base_url")
     organization: Optional[str] = None
     custom_llm_provider: Optional[str] = None
     base_model: Optional[str] = None

--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,10 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
             )
     """
 
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+
     model: str = "openai/text-embedding-3-small"
     """Model name in litellm format (e.g. 'openai/text-embedding-3-small',
     'cohere/embed-english-v3.0', 'bedrock/amazon.titan-embed-text-v1')."""
@@ -64,7 +68,7 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
     api_key: Optional[str] = None
     """API key for the provider."""
 
-    api_base: Optional[str] = None
+    api_base: Optional[str] = Field(default=None, alias="base_url")
     """Base URL for the API endpoint."""
 
     api_version: Optional[str] = None

--- a/tests/unit_tests/test_embeddings.py
+++ b/tests/unit_tests/test_embeddings.py
@@ -87,6 +87,14 @@ class TestLiteLLMEmbeddingsParams:
         embeddings = LiteLLMEmbeddings(api_key="fake", encoding_format="float")
         assert embeddings.encoding_format == "float"
 
+    def test_embeddings_base_url_alias(self):
+        """Test that base_url is accepted as an alias for api_base."""
+        embeddings = LiteLLMEmbeddings(
+            api_key="fake",
+            base_url="https://custom.endpoint.com",
+        )
+        assert embeddings.api_base == "https://custom.endpoint.com"
+
     @patch("litellm.embedding")
     def test_embed_documents(self, mock_embedding):
         """Test embed_documents calls litellm.embedding correctly."""

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -633,3 +633,13 @@ def test_client_params_does_not_mutate_litellm_globals() -> None:
     assert params["api_key"] == "azure-key"
     assert params["organization"] == "my-org"
     assert params["extra_headers"] == {"X-Custom": "value"}
+
+
+def test_chat_litellm_base_url_alias() -> None:
+    """Test that base_url is accepted as an alias for api_base."""
+    llm = ChatLiteLLM(
+        model="gpt-4",
+        api_key="fake",
+        base_url="https://custom.endpoint.com",
+    )
+    assert llm.api_base == "https://custom.endpoint.com"


### PR DESCRIPTION
# Description

- **Related Issues:** Resolves https://github.com/langchain-ai/langchain-litellm/issues/189 and https://github.com/langchain-ai/langchain-litellm/issues/202.
- **The Problem:** 
  In the `langchain-litellm` package, `ChatLiteLLM` and `LiteLLMEmbeddings` expose the API endpoint override parameter as `api_base`. However, almost all other LangChain integrations use the standard parameter name `base_url` (or support it as an alias). Because these classes inherit from Pydantic models with `extra="ignore"`, passing `base_url="https://..."` was silently ignored, causing frustration for users expecting standard parameter names.
- **The Solution:**
  - Configured `model_config = ConfigDict(populate_by_name=True)` on both `ChatLiteLLM` and `LiteLLMEmbeddings` (Pydantic v2).
  - Modified the `api_base` field to include `alias="base_url"`:
    ```python
    api_base: Optional[str] = Field(default=None, alias="base_url")
    ```
    This allows the classes to accept either parameter name during instantiation and map them correctly to `api_base`.
  - Added unit tests in `tests/unit_tests/test_litellm.py` and `tests/unit_tests/test_embeddings.py` to verify that `base_url` is properly accepted and assigned.

---

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All 66 unit tests passed successfully.