### PR TITLE
fix(chat_models): include top_p and top_k in _default_params

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -469,6 +469,8 @@ class ChatLiteLLM(BaseChatModel):
             "stream": self.streaming,
             "n": self.n,
             "temperature": self.temperature,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
             "custom_llm_provider": self.custom_llm_provider,
             "num_ctx": self.num_ctx,
             "base_model": self.base_model,

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -633,3 +633,21 @@ def test_client_params_does_not_mutate_litellm_globals() -> None:
     assert params["api_key"] == "azure-key"
     assert params["organization"] == "my-org"
     assert params["extra_headers"] == {"X-Custom": "value"}
+
+
+def test_top_p_and_top_k_in_default_params() -> None:
+    """Test that top_p and top_k are included in _default_params and _client_params."""
+    llm = ChatLiteLLM(
+        model="gpt-4",
+        api_key="fake",
+        top_p=0.8,
+        top_k=40,
+    )
+    params = llm._default_params
+    assert params["top_p"] == 0.8
+    assert params["top_k"] == 40
+
+    client_params = llm._client_params
+    assert client_params["top_p"] == 0.8
+    assert client_params["top_k"] == 40
+


### PR DESCRIPTION
### Description
Fixes #226
`ChatLiteLLM` accepts `top_p` and `top_k` as initialization parameters, range-validates them in `validate_environment`, and reports them in `_identifying_params`. However, both fields were missing from `_default_params`—the dictionary used to construct per-call parameters for `litellm.completion()`.
As a result, instantiating `ChatLiteLLM(model=..., top_p=0.1)` produced identical requests to `ChatLiteLLM(model=...)`, omitting `top_p` and `top_k` from outgoing API calls sent to downstream LiteLLM providers.
**Changes:**
- Added `"top_p": self.top_p` and `"top_k": self.top_k` to `ChatLiteLLM._default_params` in `langchain_litellm/chat_models/litellm.py`.
- Added unit test `test_top_p_and_top_k_in_default_params` in `tests/unit_tests/test_litellm.py` to verify that `top_p` and `top_k` are correctly included in `_default_params` and `_client_params`.

### Issue
Fixes #226

### Dependencies
None

### Tag Maintainer
N/A
