### PR TITLE
fix: accept base_url as alias for api_base

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -449,6 +449,20 @@ class ChatLiteLLM(BaseChatModel):
 
     max_retries: int = 1
 
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_base_url_alias(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Allow `base_url` as an alias for `api_base` (OpenAI-style kwarg).
+
+        Without this, passing `base_url=...` is silently ignored since the
+        model only recognizes `api_base`. See issue #189.
+        """
+        if isinstance(values, dict) and values.get("api_base") is None:
+            base_url = values.pop("base_url", None)
+            if base_url is not None:
+                values["api_base"] = base_url
+        return values
+
     def _thinking_config(self) -> Dict[str, Any]:
         thinking_config = self.model_kwargs.get("thinking")
         return thinking_config if isinstance(thinking_config, dict) else {}

--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,20 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
     """Input type to send when embedding queries (e.g. 'search_query'
     for Cohere, 'RETRIEVAL_QUERY' for Vertex AI). When set,
     ``embed_query`` passes this as ``input_type``."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_base_url_alias(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Allow `base_url` as an alias for `api_base` (OpenAI-style kwarg).
+
+        Without this, passing `base_url=...` is silently ignored since the
+        model only recognizes `api_base`. See issue #202.
+        """
+        if isinstance(values, dict) and values.get("api_base") is None:
+            base_url = values.pop("base_url", None)
+            if base_url is not None:
+                values["api_base"] = base_url
+        return values
 
     def _get_litellm_params(
         self, *, input_type: Optional[str] = None

--- a/tests/unit_tests/test_embeddings.py
+++ b/tests/unit_tests/test_embeddings.py
@@ -216,3 +216,25 @@ class TestLiteLLMEmbeddingsParams:
 
         call_kwargs = mock_embedding.call_args[1]
         assert "input_type" not in call_kwargs
+
+
+# ── base_url alias (issue #202) ────────────────────────────────────────────────
+
+
+def test_base_url_is_accepted_as_api_base_alias() -> None:
+    """`base_url` should populate `api_base` instead of being silently dropped."""
+    embeddings = LiteLLMEmbeddings(
+        model="openai/text-embedding-3-small",
+        base_url="http://localhost:4000",
+    )
+    assert embeddings.api_base == "http://localhost:4000"
+
+
+def test_api_base_takes_precedence_over_base_url() -> None:
+    """If both are given, the explicit `api_base` wins."""
+    embeddings = LiteLLMEmbeddings(
+        model="openai/text-embedding-3-small",
+        api_base="http://explicit",
+        base_url="http://alias",
+    )
+    assert embeddings.api_base == "http://explicit"

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -633,3 +633,23 @@ def test_client_params_does_not_mutate_litellm_globals() -> None:
     assert params["api_key"] == "azure-key"
     assert params["organization"] == "my-org"
     assert params["extra_headers"] == {"X-Custom": "value"}
+
+
+# ── base_url alias (issue #189) ────────────────────────────────────────────────
+
+
+def test_base_url_is_accepted_as_api_base_alias() -> None:
+    """`base_url` should populate `api_base` instead of being silently dropped."""
+    llm = ChatLiteLLM(model="gpt-4o-mini", base_url="http://localhost:4000")
+    assert llm.api_base == "http://localhost:4000"
+    assert llm._client_params["api_base"] == "http://localhost:4000"
+
+
+def test_api_base_takes_precedence_over_base_url() -> None:
+    """If both are given, the explicit `api_base` wins."""
+    llm = ChatLiteLLM(
+        model="gpt-4o-mini",
+        api_base="http://explicit",
+        base_url="http://alias",
+    )
+    assert llm.api_base == "http://explicit"


### PR DESCRIPTION
## What
`ChatLiteLLM` and `LiteLLMEmbeddings` only recognized `api_base`. Passing
`base_url=...` (the more common, OpenAI-style kwarg name) was silently
ignored — no error, no effect — since neither class declared that field.

## Fix
Added a `model_validator(mode="before")` to both classes that maps
`base_url` → `api_base` when `api_base` isn't already set explicitly.
If both are passed, `api_base` still takes precedence (backwards compatible).

## Testing
Added unit tests covering:
- `base_url` populates `api_base` correctly
- explicit `api_base` still wins when both are passed

All existing unit tests pass unaffected.

Fixes #189
Fixes #202