### PR TITLE
test(chat_models): pin that top_p and top_k default to None

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -469,6 +469,8 @@ class ChatLiteLLM(BaseChatModel):
             "stream": self.streaming,
             "n": self.n,
             "temperature": self.temperature,
+            "top_p": self.top_p,
+            "top_k": self.top_k,
             "custom_llm_provider": self.custom_llm_provider,
             "num_ctx": self.num_ctx,
             "base_model": self.base_model,

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -633,3 +633,22 @@ def test_client_params_does_not_mutate_litellm_globals() -> None:
     assert params["api_key"] == "azure-key"
     assert params["organization"] == "my-org"
     assert params["extra_headers"] == {"X-Custom": "value"}
+
+
+# ── top_p / top_k reach the request (issue #226) ───────────────────────────────
+
+
+def test_top_p_and_top_k_are_sent_to_litellm() -> None:
+    """`top_p`/`top_k` must reach the outgoing request, not just validation/repr."""
+    llm = ChatLiteLLM(model="gpt-4o-mini", top_p=0.9, top_k=40)
+    assert llm._default_params["top_p"] == 0.9
+    assert llm._default_params["top_k"] == 40
+    assert llm._client_params["top_p"] == 0.9
+    assert llm._client_params["top_k"] == 40
+
+
+def test_top_p_and_top_k_default_to_none() -> None:
+    """When unset, top_p/top_k should be present but None (litellm drops them)."""
+    llm = ChatLiteLLM(model="gpt-4o-mini")
+    assert llm._default_params["top_p"] is None
+    assert llm._default_params["top_k"] is None


### PR DESCRIPTION
`_default_params` carries `top_p` and `top_k` since #233, but nothing pinned the unset case. They should be present and None rather than absent, which is what lets litellm drop them instead of sending nulls.

One test, no source change. The fix itself and the set-value coverage are already on main.