### PR TITLE
fix: support base_url in LiteLLMEmbeddings

### DIFF
--- a/langchain_litellm/embeddings/litellm.py
+++ b/langchain_litellm/embeddings/litellm.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from langchain_core.embeddings import Embeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +105,15 @@ class LiteLLMEmbeddings(BaseModel, Embeddings):
     """Input type to send when embedding queries (e.g. 'search_query'
     for Cohere, 'RETRIEVAL_QUERY' for Vertex AI). When set,
     ``embed_query`` passes this as ``input_type``."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_base_url(cls, values: Any) -> Any:
+        """Map base_url to api_base for backwards-compatible configuration."""
+        if isinstance(values, dict) and "base_url" in values:
+            if "api_base" not in values:
+                values["api_base"] = values["base_url"]
+        return values
 
     def _get_litellm_params(
         self, *, input_type: Optional[str] = None

--- a/tests/unit_tests/test_embeddings.py
+++ b/tests/unit_tests/test_embeddings.py
@@ -32,6 +32,23 @@ class TestLiteLLMEmbeddingsParams:
         assert embeddings.max_retries == 1
         assert embeddings.api_base is None
 
+    def test_base_url_maps_to_api_base(self):
+        """Test that base_url is mapped to api_base."""
+        embeddings = LiteLLMEmbeddings(
+            api_key="fake",
+            base_url="https://custom.endpoint.com",
+        )
+        assert embeddings.api_base == "https://custom.endpoint.com"
+
+    def test_api_base_takes_precedence_over_base_url(self):
+        """Test that explicit api_base takes precedence over base_url."""
+        embeddings = LiteLLMEmbeddings(
+            api_key="fake",
+            base_url="https://base-url.example.com",
+            api_base="https://api-base.example.com",
+        )
+        assert embeddings.api_base == "https://api-base.example.com"
+
     def test_custom_params(self):
         """Test custom parameter passthrough."""
         embeddings = LiteLLMEmbeddings(


### PR DESCRIPTION
## Summary

Adds backwards-compatible support for `base_url` in `LiteLLMEmbeddings`.

### Changes

* Map `base_url` to `api_base` during model validation.
* Preserve explicit `api_base` when both `base_url` and `api_base` are provided.
* Add unit tests covering both behaviors.

### Testing

* `uv run pytest tests/unit_tests/test_embeddings.py`
* **21 passed**

Fixes #202
