### PR TITLE
fix(chat_models): stop injecting thinking blocks into AIMessage.content

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -111,29 +111,6 @@ def _create_retry_decorator(
     )
 
 
-def _inject_reasoning_content_into_content(
-    content: Any, reasoning_content: str
-) -> List[Dict[str, Any]]:
-    thinking_block = {"type": "thinking", "thinking": reasoning_content}
-    if isinstance(content, list):
-        has_thinking_block = any(
-            isinstance(block, dict)
-            and block.get("type") in ("thinking", "redacted_thinking")
-            for block in content
-        )
-        if has_thinking_block:
-            return content
-        return [thinking_block, *content]
-
-    if not content:
-        return [thinking_block]
-
-    if isinstance(content, str):
-        return [thinking_block, {"type": "text", "text": content}]
-
-    return [thinking_block, content]
-
-
 def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     role = _dict["role"]
     if role == "user":
@@ -199,9 +176,6 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
 
         if _dict.get("reasoning_content"):
             additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
-            content = _inject_reasoning_content_into_content(
-                content, _dict["reasoning_content"]
-            )
 
         # Check standard field first, then fallback to Vertex specific field
         provider_specific_fields = _dict.get("provider_specific_fields")
@@ -259,9 +233,6 @@ def _convert_delta_to_message_chunk(
         additional_kwargs["function_call"] = dict(function_call)
     if reasoning_content:
         additional_kwargs["reasoning_content"] = reasoning_content
-
-    if reasoning_content and (role == "assistant" or default_class == AIMessageChunk):
-        content = _inject_reasoning_content_into_content(content, reasoning_content)
 
     if provider_specific_fields is not None:
         additional_kwargs["provider_specific_fields"] = provider_specific_fields

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -22,7 +22,6 @@ from langchain_litellm.chat_models.litellm import (
     _convert_dict_to_message,
     _convert_message_to_dict,
     _create_usage_metadata,
-    _inject_reasoning_content_into_content,
 )
 
 
@@ -237,44 +236,57 @@ def test_create_usage_metadata_handles_none_values() -> None:
     assert meta["total_tokens"] == 0
 
 
-# ── reasoning content injection ────────────────────────────────────────────────
+# ── reasoning content stays out of message content ─────────────────────────────
 
 
-def test_inject_reasoning_content_into_string_content() -> None:
-    result = _inject_reasoning_content_into_content("answer", "hidden chain")
+def test_reasoning_content_does_not_alter_content_for_dict() -> None:
+    """`.content` must stay a plain str; reasoning_content lives in additional_kwargs."""
+    mock_dict = {
+        "role": "assistant",
+        "content": "answer",
+        "reasoning_content": "hidden chain",
+    }
 
-    assert result == [
-        {"type": "thinking", "thinking": "hidden chain"},
-        {"type": "text", "text": "answer"},
-    ]
+    message = _convert_dict_to_message(mock_dict)
 
-
-def test_inject_reasoning_content_into_empty_content() -> None:
-    result = _inject_reasoning_content_into_content("", "hidden chain")
-
-    assert result == [{"type": "thinking", "thinking": "hidden chain"}]
-
-
-def test_inject_reasoning_content_prepends_for_list_without_thinking() -> None:
-    content = [{"type": "text", "text": "answer"}]
-
-    result = _inject_reasoning_content_into_content(content, "hidden chain")
-
-    assert result == [
-        {"type": "thinking", "thinking": "hidden chain"},
-        {"type": "text", "text": "answer"},
-    ]
+    assert message.content == "answer"
+    assert message.additional_kwargs["reasoning_content"] == "hidden chain"
 
 
-def test_inject_reasoning_content_does_not_duplicate_existing_thinking() -> None:
-    content = [
-        {"type": "thinking", "thinking": "already there"},
-        {"type": "text", "text": "answer"},
-    ]
+def test_reasoning_content_does_not_alter_empty_content_for_dict() -> None:
+    mock_dict = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "hidden chain",
+    }
 
-    result = _inject_reasoning_content_into_content(content, "hidden chain")
+    message = _convert_dict_to_message(mock_dict)
 
-    assert result == content
+    assert message.content == ""
+    assert message.additional_kwargs["reasoning_content"] == "hidden chain"
+
+
+def test_reasoning_content_does_not_alter_content_for_delta() -> None:
+    mock_delta = {
+        "role": "assistant",
+        "content": "answer",
+        "reasoning_content": "hidden chain",
+    }
+
+    chunk = _convert_delta_to_message_chunk(mock_delta, AIMessageChunk)
+
+    assert chunk.content == "answer"
+    assert chunk.additional_kwargs["reasoning_content"] == "hidden chain"
+
+
+def test_reasoning_content_surfaces_as_standard_content_block() -> None:
+    """Consumers reading the standard `content_blocks` API (e.g. LangGraph) still
+    see reasoning content even though it is no longer duplicated into `.content`."""
+    message = AIMessage(
+        content="answer", additional_kwargs={"reasoning_content": "hidden chain"}
+    )
+
+    assert {"type": "reasoning", "reasoning": "hidden chain"} in message.content_blocks
 
 
 # ── credential forwarding ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #216

## What

`_convert_dict_to_message` and `_convert_delta_to_message_chunk` both called `_inject_reasoning_content_into_content`, which prepended a `{"type": "thinking", "thinking": ...}` block into `AIMessage.content` whenever the response carried `reasoning_content` — turning `.content` from a `str` into a `list` for every response from a reasoning-capable model. The same data was already stored in `additional_kwargs["reasoning_content"]` in the same message, so the injected block added no information a consumer couldn't already read from the kwarg.

This PR removes `_inject_reasoning_content_into_content` entirely and its two call sites. `additional_kwargs["reasoning_content"]` capture is unchanged in both the non-streaming and streaming paths. `ChatLiteLLMRouter` is covered too, since `litellm_router.py` reuses these same conversion functions rather than duplicating them.

## Why this doesn't reintroduce #71/#85

The injection was originally added in #85 (fixing #71) because at the time `_convert_message_to_dict` (the outbound serializer) only read `message.content` and ignored `additional_kwargs` entirely, so `reasoning_content` had no other way to reach the outbound request — without it, Anthropic/Bedrock rejected continuation turns. That gap was independently closed by #159, which added direct forwarding of `additional_kwargs["reasoning_content"]` into the outbound message dict, decoupled from whatever `.content` contains. So the round-trip `#85` was created to fix still works after this change.

I also confirmed `AIMessage.content_blocks` (langchain-core 1.4.7), which LangGraph and other standard-content consumers use, already has its own fallback that synthesizes a standard `{"type": "reasoning", ...}` block directly from `additional_kwargs["reasoning_content"]` whenever `.content` doesn't already carry one — see `_extract_reasoning_from_additional_kwargs` in `langchain_core/messages/base.py`. So consumers reading the standard API see no behavior change; only the raw, non-standard `.content` shape changes (back to a plain string, as it is for every non-reasoning response).

## Breaking change note

Any caller that was relying on `.content` being a list containing an inline `thinking` block (rather than reading `additional_kwargs["reasoning_content"]` or `.content_blocks`) will see `.content` revert to a plain string. This aligns with the expected behavior across standard LangChain chat models and resolves inconsistency for reasoning-capable providers.

## Tests

Replaced the 4 tests that asserted the old injection behavior directly (`test_inject_reasoning_content_*`, now removed along with the deleted helper) with 4 new tests in `tests/unit_tests/test_litellm.py`:

- `test_reasoning_content_does_not_alter_content_for_dict`
- `test_reasoning_content_does_not_alter_empty_content_for_dict`
- `test_reasoning_content_does_not_alter_content_for_delta`
- `test_reasoning_content_surfaces_as_standard_content_block`

## How I verified

- `make format`, `make lint` (ruff + mypy), `make test` all pass.
- Verified against the repro script in #216 to ensure `.content` remains a string (`"hi"`) while `reasoning_content` resides in `additional_kwargs`.
- Full unit suite: 65 passed, 4 skipped with zero regressions.