### PR TITLE
fix(chat_models): honor per-call model override in _get_ls_params

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -1022,10 +1022,14 @@ class ChatLiteLLM(BaseChatModel):
         against ``ls_provider`` to decide whether reported token counts should be
         trusted. Without this override, ``ls_provider`` would be absent and that
         middleware check would always short-circuit.
+
+        ``ls_model_name`` resolves ``kwargs["model"]`` first because ``_generate``
+        merges per-call kwargs over the default params, so a ``model`` passed to
+        ``bind`` or ``invoke`` is the model actually requested.
         """
         params = super()._get_ls_params(stop=stop, **kwargs)
         params["ls_provider"] = "litellm"
-        params["ls_model_name"] = self.model_name or self.model
+        params["ls_model_name"] = kwargs.get("model") or self.model_name or self.model
         return params
 
     @property

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -554,6 +554,27 @@ def test_get_ls_params_sets_ls_provider() -> None:
     assert params["ls_model_name"] == "my-deployment"
 
 
+def test_get_ls_params_honors_per_call_model_override() -> None:
+    """A per-call `model` kwarg must be reflected in traces.
+
+    `_generate` merges per-call kwargs over the default params, so a `model`
+    passed via `bind` or `invoke` is the model actually requested. Reporting
+    the constructor default instead misattributes the run.
+    """
+    llm = ChatLiteLLM(model="gpt-4", api_key="fake")
+    assert llm._get_ls_params(model="gpt-4o-mini")["ls_model_name"] == "gpt-4o-mini"
+
+    # The override also wins over an explicitly configured model_name.
+    llm_with_name = ChatLiteLLM(
+        model="gpt-4", model_name="my-deployment", api_key="fake"
+    )
+    params = llm_with_name._get_ls_params(model="gpt-4o-mini")
+    assert params["ls_model_name"] == "gpt-4o-mini"
+
+    # Without an override the configured model_name is still used.
+    assert llm_with_name._get_ls_params()["ls_model_name"] == "my-deployment"
+
+
 def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatLiteLLM(model="gpt-4", api_key="fake")


### PR DESCRIPTION
`_get_ls_params` always reported the constructor's model, so a `model` passed through `bind()` or `invoke()` was traced as the wrong model — even though `_generate` merges per-call kwargs over the default params and sends the override to litellm. This resolves `kwargs["model"]` first, matching the order documented on `BaseChatModel._get_ls_params`.

This fixes the standard test `test_standard_params_model_override`, which currently fails on `main` for both `ChatLiteLLM` and `ChatLiteLLMRouter` (the router inherits the method).

**How I verified**

- `pytest tests/unit_tests` goes from `2 failed, 119 passed, 4 skipped` to `122 passed, 4 skipped`. The two failures were the standard test above; the extra passing test is the one added here.
- `ruff check`, `ruff format --diff` and `mypy langchain_litellm` are clean.
- Confirmed the override actually reaches litellm by capturing the outbound call: on a model constructed as `gpt-3.5-turbo`, `invoke("hi", model="gpt-4o-mini")` sends `gpt-4o-mini`, while `ls_model_name` reported `gpt-3.5-turbo` before this change. Same via `.bind(model=...)`.

Added `test_get_ls_params_honors_per_call_model_override`, covering the override, its precedence over `model_name`, and the unchanged fallback when no override is passed.

No new dependencies, no changes to `pyproject.toml` or `uv.lock`.

_Disclaimer: I used AI assistance while investigating and drafting this change. Every result reported above was run and verified locally._
