### PR TITLE
chore(lint): select a minimal ruff rule set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,13 @@ disallow_untyped_defs = false
 docstring-code-format = true  # Formats code blocks in docstrings
 
 [tool.ruff.lint]
+# An empty `select` selects no rules at all, which also makes every entry in
+# `ignore` and `per-file-ignores` below inert. These are ruff's defaults.
 select = [
+    "E4",  # pycodestyle — imports
+    "E7",  # pycodestyle — statements
+    "E9",  # pycodestyle — syntax and IO errors
+    "F",   # Pyflakes — undefined names, unused imports and variables
     #"ALL"  # Enable all rules by default (TODO)
 ]
 ignore = [


### PR DESCRIPTION
`[tool.ruff.lint] select` is an empty list — the single entry is commented out:

```toml
[tool.ruff.lint]
select = [
    #"ALL"  # Enable all rules by default (TODO)
]
```

An empty `select` selects no rules, so `ruff check` reports nothing. It also makes the `ignore` list and the whole `per-file-ignores` block below it inert, since there is nothing selected for them to subtract from. In practice `make lint` currently enforces only `ruff format --diff` and mypy.

**Demonstration**

This file passes `ruff check` on `main`:

```python
import os
import json


def broken(  ):
    x = 1
    return undefined_name
```

With this change it reports four errors (`F401` twice, `F841`, `F821`).

**Why this rule set**

These four are ruff's own documented defaults, which is the smallest change that makes the existing config meaningful. The tree is already clean under them:

- `ruff check langchain_litellm tests scripts` — all checks passed
- `ruff format --diff` — 27 files already formatted, unchanged
- `mypy langchain_litellm` — no issues in 10 source files

So this adds enforcement with zero code churn. I deliberately did not expand beyond the defaults; the `ALL` TODO is left in place for whenever you want to take that on, and picking a wider set is your call rather than something to smuggle into a config fix.

`make format` is unaffected — it passes `--select I` explicitly, which works regardless of the configured `select`.

Titled `chore` rather than `fix` so release-please doesn't cut a patch release for a config-only change with no user-visible effect. Happy to retitle if you'd rather it appear in the changelog.

_Disclaimer: I used AI assistance while investigating and drafting this change. Every result reported above was run and verified locally._
