### PR TITLE
chore(makefile): repair lint_diff and format_diff after the repo extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all format lint test tests integration_tests docker_tests help extended_tests
+.PHONY: all help format format_diff lint lint_diff lint_package lint_tests \
+	test tests test_watch integration_test integration_tests \
+	spell_check spell_fix check_imports
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -27,7 +29,7 @@ integration_test integration_tests:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/litellm --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --name-only --diff-filter=d main | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_litellm
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test


### PR DESCRIPTION
`lint_diff` and `format_diff` still carry two assumptions from the langchain monorepo:

```make
lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/litellm --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
```

- the diff base is `master`, but this repository's default branch is `main`
- `--relative=libs/partners/litellm` scopes the diff to a path that doesn't exist here

`$(shell ...)` discards the non-zero exit and returns an empty string, so `PYTHON_FILES` is always empty and both targets quietly check nothing rather than failing loudly.

**Verified**

```
$ git diff --relative=libs/partners/litellm --name-only --diff-filter=d master
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.

$ git diff --name-only --diff-filter=d main | grep -E '\.py$|\.ipynb$'
langchain_litellm/chat_models/litellm.py
tests/unit_tests/test_litellm.py
```

(second command run against a branch that touches Python files, to show selection works rather than just that the command exits cleanly)

**Second hunk**

`.PHONY` declared `docker_tests` and `extended_tests`, neither of which has a recipe, while omitting most targets that do exist. Updated to match the file. Separable from the fix above if you'd prefer it dropped — say so and I'll drop the hunk.

I could not run `make` itself to verify end to end (no `make` on this machine), so I evaluated the recipe's shell command directly in bash, as shown above.

_Disclaimer: I used AI assistance while investigating and drafting this change. Every result reported above was run and verified locally._
