### PR TITLE
chore(scripts): replace load_module() in check_imports, removed in Python 3.15

### DIFF
--- a/scripts/check_imports.py
+++ b/scripts/check_imports.py
@@ -1,13 +1,18 @@
+import importlib.util
 import sys
 import traceback
-from importlib.machinery import SourceFileLoader
+from pathlib import Path
 
 if __name__ == "__main__":
     files = sys.argv[1:]
     has_failure = False
     for file in files:
+        module_name = ".".join(Path(file).with_suffix("").parts)
         try:
-            SourceFileLoader("x", file).load_module()
+            spec = importlib.util.spec_from_file_location(module_name, file)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"could not determine a loader for {file}")
+            spec.loader.exec_module(importlib.util.module_from_spec(spec))
         except Exception:
             has_failure = True
             print(file)  # noqa: T201


### PR DESCRIPTION
Fixes #256.

`SourceFileLoader.load_module()` is deprecated and slated for removal in Python 3.15, at which point `make check_imports` stops working. `pyproject.toml` already advertises `Programming Language :: Python :: 3.14` and allows `requires-python = ">=3.10,<4.0"`, so 3.15 falls inside the declared support range.

The warning is silenced by default, so nothing fails today — this is pre-emptive.

```
$ python -W error::DeprecationWarning ./scripts/check_imports.py langchain_litellm/_version.py
DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.15; use exec_module() instead
```

Switched to the documented replacement (`spec_from_file_location` + `module_from_spec` + `exec_module`).

**Two incidental improvements**

Every file was previously loaded under the shared literal name `"x"`. Because `load_module()` registers in `sys.modules` and returns an existing entry when the name is already present, the files were partly checking each other rather than themselves. Now each is loaded under its real dotted module name, and `exec_module` doesn't touch `sys.modules`, so each import is genuinely checked in isolation.

**Verified**

- all 10 package modules, run with `-W error::DeprecationWarning`: current script exits 1, this one exits 0
- a file importing a nonexistent module is still reported with its traceback and a non-zero exit, so the script hasn't become permissive
- `ruff format --diff`, `ruff check` and `mypy` clean on the file

Titled `chore` rather than `fix` because `scripts/` isn't shipped in the wheel, so this shouldn't cut a patch release. Happy to retitle if you'd rather it appear in the changelog.

I used the dotted module name here rather than the `Path(file).stem` I sketched in #256 — same fix, slightly more faithful naming.

_Disclaimer: I used AI assistance while investigating and drafting this change. Every result reported above was run and verified locally._
