### PR TITLE
fix(chat_models): report unparsable tool-call arguments as invalid

### DIFF
--- a/langchain_litellm/chat_models/litellm.py
+++ b/langchain_litellm/chat_models/litellm.py
@@ -48,6 +48,7 @@ from langchain_core.messages import (
     FunctionMessageChunk,
     HumanMessage,
     HumanMessageChunk,
+    InvalidToolCall,
     SystemMessage,
     SystemMessageChunk,
     ToolCall,
@@ -59,6 +60,7 @@ from langchain_core.messages.ai import (
     OutputTokenDetails,
     UsageMetadata,
 )
+from langchain_core.messages.tool import invalid_tool_call
 from langchain_core.messages.utils import (
     convert_to_openai_data_block,
     is_data_content_block,
@@ -143,6 +145,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
 
         additional_kwargs = {}
         tool_calls = []
+        invalid_tool_calls: List[InvalidToolCall] = []
 
         if _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(_dict["function_call"])
@@ -182,7 +185,20 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                             try:
                                 func_args = json.loads(func_args)
                             except json.JSONDecodeError:
-                                pass  # Keep as string or empty if strictly required
+                                # Arguments that don't parse cannot be recovered,
+                                # so report the call as invalid rather than
+                                # dispatching the tool with no arguments. Matches
+                                # langchain_core's default_tool_parser, which keeps
+                                # the raw string for inspection.
+                                invalid_tool_calls.append(
+                                    invalid_tool_call(
+                                        name=func_name,
+                                        args=func_args,
+                                        id=tc_id,
+                                        error=None,
+                                    )
+                                )
+                                continue
 
                         # Ensure args is a dict (e.g., already parsed Dict from Vertex)
                         if not isinstance(func_args, dict):
@@ -212,7 +228,10 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
             additional_kwargs["provider_specific_fields"] = provider_specific_fields
 
         return AIMessage(
-            content=content, additional_kwargs=additional_kwargs, tool_calls=tool_calls
+            content=content,
+            additional_kwargs=additional_kwargs,
+            tool_calls=tool_calls,
+            invalid_tool_calls=invalid_tool_calls,
         )
 
     elif role == "system":

--- a/tests/unit_tests/test_litellm.py
+++ b/tests/unit_tests/test_litellm.py
@@ -78,6 +78,72 @@ def test_convert_dict_to_tool_message() -> None:
     assert message.tool_call_id == "123"
 
 
+def test_malformed_tool_call_arguments_are_reported_as_invalid() -> None:
+    """Unparsable arguments must not become a tool call with empty args.
+
+    A truncated `arguments` string cannot be recovered. Returning it as a valid
+    tool call with `args={}` makes an agent invoke the tool with no input and
+    leaves it no way to detect the failure, so the call belongs in
+    `invalid_tool_calls` with the raw string kept for inspection.
+    """
+    raw_arguments = '{"city": "Par'
+    message = _convert_dict_to_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": raw_arguments},
+                }
+            ],
+        }
+    )
+
+    assert isinstance(message, AIMessage)
+    assert message.tool_calls == []
+    assert len(message.invalid_tool_calls) == 1
+
+    invalid = message.invalid_tool_calls[0]
+    assert invalid["name"] == "get_weather"
+    assert invalid["args"] == raw_arguments
+    assert invalid["id"] == "call_1"
+
+
+def test_tool_calls_partition_valid_and_invalid_arguments() -> None:
+    """Valid calls in the same response are unaffected by an invalid sibling."""
+    message = _convert_dict_to_message(
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "ok",
+                    "type": "function",
+                    "function": {"name": "with_args", "arguments": '{"x": 1}'},
+                },
+                {
+                    "id": "bad",
+                    "type": "function",
+                    "function": {"name": "broken", "arguments": "{oops"},
+                },
+                {
+                    "id": "empty",
+                    "type": "function",
+                    "function": {"name": "no_args", "arguments": "{}"},
+                },
+            ],
+        }
+    )
+
+    assert isinstance(message, AIMessage)
+    assert [tc["name"] for tc in message.tool_calls] == ["with_args", "no_args"]
+    assert message.tool_calls[0]["args"] == {"x": 1}
+    assert message.tool_calls[1]["args"] == {}
+    assert [tc["name"] for tc in message.invalid_tool_calls] == ["broken"]
+
+
 def test_provider_specific_fields_in_delta() -> None:
     """Test that provider_specific_fields are preserved when converting deltas."""
     mock_delta = {


### PR DESCRIPTION
Fixes #249.

`_convert_dict_to_message` caught `json.JSONDecodeError` and fell through to `if not isinstance(func_args, dict): func_args = {}`, so a tool call with truncated or malformed arguments came back as a **valid** tool call with no arguments. An agent then invoked the tool with empty input and had no way to notice: `tool_calls` held an executable call, `invalid_tool_calls` was empty, and `finish_reason` was still `"tool_calls"`.

**Before**

```python
_convert_dict_to_message({
    "role": "assistant",
    "content": "",
    "tool_calls": [{
        "id": "call_1",
        "type": "function",
        "function": {"name": "get_weather", "arguments": '{"city": "Par'},
    }],
})
# .tool_calls         -> [{'name': 'get_weather', 'args': {}, 'id': 'call_1', ...}]
# .invalid_tool_calls -> []
```

After, the call lands in `invalid_tool_calls` with the raw string preserved, mirroring `langchain_core.messages.tool.default_tool_parser`. I used core's `invalid_tool_call` factory so entries carry the right discriminator.

**Deliberately narrow**

Only arguments that raise `JSONDecodeError` change behaviour. Arguments that parse are untouched, including `"{}"` for a no-argument call, and the existing non-dict coercion still guards already-parsed payloads such as Vertex's. Streaming is unaffected — partial argument strings arrive via `_convert_delta_to_message_chunk` as `tool_call_chunks` and are accumulated by design. The raw payload also remains in `additional_kwargs["tool_calls"]` either way.

**One edge worth your call**

An `arguments` value of `""` now becomes an invalid tool call rather than an empty-args one. That is exactly what `default_tool_parser` does with `""`, so this matches core, and in non-streaming responses OpenAI sends `"{}"` rather than `""` for zero-argument tools. But if you know of a provider that emits `""` for a legitimate no-argument call in a non-streaming response, say so and I'll special-case empty/whitespace strings to `{}`.

**Tests**

Two added: one asserting a truncated payload produces a single `invalid_tool_call` carrying the raw string, name and id; one asserting a response mixing valid, malformed and `"{}"` arguments partitions correctly and that a broken sibling doesn't disturb the valid calls.

**Verified**

`pytest tests/unit_tests` gives `124 passed, 4 skipped` plus the two pre-existing `test_standard_params_model_override` failures, which also fail on unmodified `main` and are what #248 fixes — unrelated to this change. `ruff check`, `ruff format --diff` and `mypy langchain_litellm` are clean.

_Disclaimer: I used AI assistance while investigating and drafting this change. Every result reported above was run and verified locally._
