### PR TITLE
fix(router): honour max_retries in ChatLiteLLMRouter

### DIFF
--- a/langchain_litellm/chat_models/litellm_router.py
+++ b/langchain_litellm/chat_models/litellm_router.py
@@ -21,6 +21,7 @@ from langchain_litellm.chat_models.litellm import (
     ChatLiteLLM,
     _convert_delta_to_message_chunk,
     _convert_dict_to_message,
+    _create_retry_decorator,
     _create_usage_metadata,
 )
 
@@ -81,6 +82,44 @@ class ChatLiteLLMRouter(ChatLiteLLM):
                 return
         raise ValueError(f"Model {model_name} not found in model_list.")
 
+    def completion_with_retry(
+        self, run_manager: Optional[CallbackManagerForLLMRun] = None, **kwargs: Any
+    ) -> Any:
+        """Use tenacity to retry the router completion call.
+
+        Note: `max_retries` here is independent of any retry/fallback
+        configuration (e.g. `num_retries`, `fallbacks`) set on the
+        underlying `litellm.Router` instance. If both are configured,
+        retries will stack.
+        """
+        retry_decorator = _create_retry_decorator(self, run_manager=run_manager)
+
+        @retry_decorator
+        def _completion_with_retry(**kwargs: Any) -> Any:
+            return self.router.completion(**kwargs)
+
+        return _completion_with_retry(**kwargs)
+
+    async def acompletion_with_retry(
+        self,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Use tenacity to retry the async router completion call.
+
+        Note: `max_retries` here is independent of any retry/fallback
+        configuration (e.g. `num_retries`, `fallbacks`) set on the
+        underlying `litellm.Router` instance. If both are configured,
+        retries will stack.
+        """
+        retry_decorator = _create_retry_decorator(self, run_manager=run_manager)
+
+        @retry_decorator
+        async def _completion_with_retry(**kwargs: Any) -> Any:
+            return await self.router.acompletion(**kwargs)
+
+        return await _completion_with_retry(**kwargs)
+
     def _generate(
         self,
         messages: List[BaseMessage],
@@ -101,9 +140,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         params = {k: v for k, v in params.items() if v is not None}
         self._prepare_params_for_router(params)
 
-        response = self.router.completion(
-            messages=message_dicts,
-            **params,
+        response = self.completion_with_retry(
+            messages=message_dicts, run_manager=run_manager, **params
         )
         return self._create_chat_result(response, **params)
 
@@ -126,7 +164,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         self._prepare_params_for_router(params)
         first_chunk_yielded = False
 
-        for chunk in self.router.completion(messages=message_dicts, **params):
+        for chunk in self.completion_with_retry(
+            messages=message_dicts, run_manager=run_manager, **params):
             usage_metadata = None
             if "usage" in chunk and chunk["usage"]:
                 usage_metadata = _create_usage_metadata(chunk["usage"])
@@ -185,8 +224,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         self._prepare_params_for_router(params)
         first_chunk_yielded = False
 
-        async for chunk in await self.router.acompletion(
-            messages=message_dicts, **params
+        async for chunk in await self.acompletion_with_retry(
+            messages=message_dicts, run_manager=run_manager, **params
         ):
             # Parse usage metadata first
             usage_metadata = None
@@ -248,9 +287,8 @@ class ChatLiteLLMRouter(ChatLiteLLM):
         params = {k: v for k, v in params.items() if v is not None}
         self._prepare_params_for_router(params)
 
-        response = await self.router.acompletion(
-            messages=message_dicts,
-            **params,
+        response = await self.acompletion_with_retry(
+            messages=message_dicts, run_manager=run_manager, **params
         )
         return self._create_chat_result(response, **params)
 

--- a/tests/unit_tests/test_router.py
+++ b/tests/unit_tests/test_router.py
@@ -1,10 +1,20 @@
 """Test router chat model integration."""
 
+from unittest.mock import patch
+
+import litellm
+import pytest
 from langchain_core.messages import AIMessage
 
 from langchain_litellm._version import __version__
 from langchain_litellm.chat_models import ChatLiteLLMRouter
 from tests.utils import make_router
+
+
+def _rate_limit_error() -> litellm.RateLimitError:
+    return litellm.RateLimitError(
+        message="rate limited", llm_provider="openai", model="gpt-4"
+    )
 
 
 def test_router_provider_specific_fields_in_chat_result() -> None:
@@ -120,3 +130,80 @@ def test_router_stream_sets_model_provider_in_response_metadata() -> None:
 
     assert chunks[0].message.response_metadata.get("model_provider") == "litellm"
     assert chunks[1].message.response_metadata == {}
+
+def test_router_generate_honours_max_retries() -> None:
+    """ChatLiteLLMRouter._generate must retry via completion_with_retry.
+
+    Regression test: previously `_generate` called `self.router.completion`
+    directly, bypassing the tenacity retry decorator entirely, so
+    `max_retries` had no effect for `ChatLiteLLMRouter`.
+    """
+    router = make_router()
+    llm = ChatLiteLLMRouter(router=router, max_retries=4)
+
+    with patch.object(
+        llm.router, "completion", side_effect=_rate_limit_error()
+    ) as mock_completion:
+        with patch("time.sleep", return_value=None):  # skip tenacity backoff
+            with pytest.raises(litellm.RateLimitError):
+                llm.invoke("hi")
+
+    assert mock_completion.call_count == 4
+
+
+def test_router_stream_honours_max_retries() -> None:
+    """ChatLiteLLMRouter._stream must retry via completion_with_retry."""
+    router = make_router()
+    llm = ChatLiteLLMRouter(router=router, max_retries=4, streaming=True)
+
+    with patch.object(
+        llm.router, "completion", side_effect=_rate_limit_error()
+    ) as mock_completion:
+        with patch("time.sleep", return_value=None):
+            with pytest.raises(litellm.RateLimitError):
+                list(llm.stream("hi"))
+
+    assert mock_completion.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_router_agenerate_honours_max_retries() -> None:
+    """ChatLiteLLMRouter._agenerate must retry via acompletion_with_retry."""
+    router = make_router()
+    llm = ChatLiteLLMRouter(router=router, max_retries=4)
+
+    async def _raise(**kwargs: object) -> None:
+        raise _rate_limit_error()
+
+    with patch.object(llm.router, "acompletion", side_effect=_raise) as mock_acompletion:
+        with patch("asyncio.sleep", return_value=None):  # skip tenacity backoff
+            with pytest.raises(litellm.RateLimitError):
+                await llm.ainvoke("hi")
+
+    assert mock_acompletion.call_count == 4
+
+
+def test_router_generate_no_retry_on_success() -> None:
+    """A successful router call must not be retried unnecessarily."""
+    from litellm.utils import Usage
+
+    router = make_router()
+    llm = ChatLiteLLMRouter(router=router, max_retries=4)
+
+    mock_response = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    }
+
+    with patch.object(
+        llm.router, "completion", return_value=mock_response
+    ) as mock_completion:
+        result = llm.invoke("hi")
+
+    assert mock_completion.call_count == 1
+    assert result.content == "hello"


### PR DESCRIPTION
   ## Problem
   `ChatLiteLLMRouter._generate/_agenerate/_stream/_astream` called
   `self.router.completion`/`acompletion` directly, bypassing the tenacity
   retry decorator used by `ChatLiteLLM`. This meant the inherited
   `max_retries` field silently had no effect — a router configured with
   `max_retries=4` would only ever attempt the call once on failure.

   ## Fix
   Added `completion_with_retry` / `acompletion_with_retry` to
   `ChatLiteLLMRouter`, reusing the existing `_create_retry_decorator`
   from `ChatLiteLLM`, and routed all four call sites (`_generate`,
   `_agenerate`, `_stream`, `_astream`) through them.

   **Note:** retries now stack with any `num_retries`/`fallbacks` already
   configured on the underlying `litellm.Router` instance. If both are
   set, expect more total attempts than either alone.

   ## Testing
   Added 4 regression tests in `tests/unit_tests/test_router.py` covering
   sync generate, stream, async agenerate, and the success path (to
   confirm no unnecessary retries happen when calls succeed).

   Ran locally:
   - `python -m pytest tests/unit_tests/` → all relevant tests pass
   - `ruff check` / `ruff format --diff` → clean
   - `mypy` → no issues

   Fixes #252